### PR TITLE
update for new launcher

### DIFF
--- a/adsbhub/Dockerfile-adsbhub
+++ b/adsbhub/Dockerfile-adsbhub
@@ -1,9 +1,9 @@
 FROM multiarch/alpine:armhf-v3.9
 
-RUN apk add --no-cache socat iputils
+RUN apk add --no-cache socat iputils bash
 
-COPY adsbhub-client.sh /usr/local/bin/adsbhub-client
-ENTRYPOINT ["adsbhub-client"]
+COPY adsbhub.sh /usr/bin/adsbhub.sh
+ENTRYPOINT ["adsbhub.sh"]
 
 # Metadata
 ARG VCS_REF="Unknown"


### PR DESCRIPTION
The new adsbub launcher requires bash to be installed. I changed the COPY and ENTRYPOINT lines to account for the new name. I don't know if the .sh is required in the ENTRYPOINT statement but that's what I needed to do to get it to work.